### PR TITLE
Merge PR #2438 from the-via/keyboards: Add VIA support for Coban Pad 12A

### DIFF
--- a/v3/coban/pad12a/pad12a.json
+++ b/v3/coban/pad12a/pad12a.json
@@ -1,0 +1,13 @@
+{
+  "name": "Coban Pad 12A",
+  "vendorId": "0xCB3A",
+  "productId": "0xC12A",
+  "matrix": { "rows": 3, "cols": 4 },
+  "layouts": {
+      "keymap": [
+          ["0,0\n\n\n\n\n\n\n\n\ne0", "0,1", "0,2", "0,3"],
+          ["1,0", "1,1", "1,2", "1,3"],
+          ["2,0", "2,1", "2,2", "2,3"]
+        ]
+  }
+}


### PR DESCRIPTION
Automatically merging PR #2438 from https://github.com/the-via/keyboards/

Original PR: https://github.com/the-via/keyboards/pull/2438